### PR TITLE
[WIP] [DO-NOT-MERGE] Test invalid fixtures

### DIFF
--- a/.github/kubevalidator.yaml
+++ b/.github/kubevalidator.yaml
@@ -8,8 +8,8 @@ spec:
       strict: true
   # Test yoself
   # Uncomment me to iterate on line number fixtures using the checks ui
-  # - glob: fixtures/line-numbers/*.yaml
-  #   schemas:
-  #   - version: 1.10.0
-  #     strict: true
-  #     lineNumbers: true
+  - glob: fixtures/line-numbers/*.yaml
+    schemas:
+    - version: 1.10.0
+      strict: true
+      lineNumbers: true


### PR DESCRIPTION
A PR configured to test our collection of invalid YAML files line number detection enabled. Can be used to observe the status of https://github.com/urcomputeringpal/kubevalidator/issues/7 as I chip away at it.