### PR TITLE
Default to strict validation

### DIFF
--- a/.github/kubevalidator.yaml
+++ b/.github/kubevalidator.yaml
@@ -5,11 +5,3 @@ spec:
   - glob: config/kubernetes/default/*/*.yaml
     schemas:
     - version: 1.10.0
-      strict: true
-  # Test yoself
-  # Uncomment me to iterate on line number fixtures using the checks ui
-  # - glob: fixtures/line-numbers/*.yaml
-  #   schemas:
-  #   - version: 1.10.0
-  #     strict: true
-  #     lineNumbers: true

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ spec:
 
     # version: 'master'
     # name: $version
-    # strict: false
 
     # If the schemas at https://github.com/garethr/kubernetes-json-schema
     # don't work for you, fork it and drop your username here! Your schemas

--- a/fixtures/kubevalidator.yaml
+++ b/fixtures/kubevalidator.yaml
@@ -5,4 +5,3 @@ spec:
   - glob: fixtures/*.yaml
     schemas:
     - version: 1.10.0
-      strict: true

--- a/validator/candidate.go
+++ b/validator/candidate.go
@@ -32,7 +32,6 @@ var (
 		Version:    "master",
 		SchemaFork: "garethr",
 		ConfigType: "kubernetes",
-		Strict:     false,
 	}
 )
 
@@ -89,7 +88,8 @@ func (c *Candidate) Validate() Annotations {
 			kubeval.Version = schema.Version
 		}
 
-		kubeval.Strict = schema.Strict
+		// TODO configurable
+		kubeval.Strict = true
 		if schema.ConfigType == "openstack" {
 			kubeval.OpenShift = true
 		} else {
@@ -101,8 +101,6 @@ func (c *Candidate) Validate() Annotations {
 			schemaName = schema.Name
 		} else if schema.Version != "" {
 			schemaName = schema.Version
-		} else if schema.Strict {
-			schemaName = "strict"
 		} else {
 			schemaName = "default"
 		}

--- a/validator/candidate_test.go
+++ b/validator/candidate_test.go
@@ -76,9 +76,7 @@ func TestAnnotationsForInvalidCandidate(t *testing.T) {
 }
 
 func TestAnnotationsForCandidateWithMultipleFailures(t *testing.T) {
-	schema := &KubeValidatorConfigSchema{
-		Strict: true,
-	}
+	schema := &KubeValidatorConfigSchema{}
 	var schemas []*KubeValidatorConfigSchema
 	schemas = append(schemas, schema)
 	candidate := NewCandidate(
@@ -102,7 +100,7 @@ func TestAnnotationsForCandidateWithMultipleFailures(t *testing.T) {
 			StartLine:       github.Int(1),
 			EndLine:         github.Int(1),
 			AnnotationLevel: github.String("failure"),
-			Title:           github.String("Error validating Deployment against strict schema"),
+			Title:           github.String("Error validating Deployment against default schema"),
 			Message:         github.String("extra: Additional property extra is not allowed"),
 			RawDetails:      github.String("* context: (root).spec\n* field: extra\n* property: extra\n"),
 		},
@@ -112,7 +110,7 @@ func TestAnnotationsForCandidateWithMultipleFailures(t *testing.T) {
 			StartLine:       github.Int(1),
 			EndLine:         github.Int(1),
 			AnnotationLevel: github.String("failure"),
-			Title:           github.String("Error validating Deployment against strict schema"),
+			Title:           github.String("Error validating Deployment against default schema"),
 			Message:         github.String("spec.replicas: Invalid type. Expected: integer, given: string"),
 			RawDetails:      github.String("* context: (root).spec.replicas\n* expected: integer\n* field: spec.replicas\n* given: string\n"),
 		},
@@ -122,7 +120,7 @@ func TestAnnotationsForCandidateWithMultipleFailures(t *testing.T) {
 			StartLine:       github.Int(1),
 			EndLine:         github.Int(1),
 			AnnotationLevel: github.String("failure"),
-			Title:           github.String("Error validating Deployment against strict schema"),
+			Title:           github.String("Error validating Deployment against default schema"),
 			Message:         github.String("extra-container: Additional property extra-container is not allowed"),
 			RawDetails:      github.String("* context: (root).spec.template.spec.containers.0\n* field: extra-container\n* property: extra-container\n"),
 		},

--- a/validator/candidate_test.go
+++ b/validator/candidate_test.go
@@ -190,7 +190,7 @@ func TestAnnotationsWithCustomSchemaFailure(t *testing.T) {
 		EndLine:         github.Int(1),
 		AnnotationLevel: github.String("failure"),
 		Title:           github.String("Error validating VolumeError against 1.6.0 schema"),
-		Message:         github.String("1 error occurred:\n\t* Problem loading schema from the network at https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.6.0-standalone/volumeerror.json: Could not read schema from HTTP, response status is 404 Not Found\n\n"),
+		Message:         github.String("1 error occurred:\n\t* Problem loading schema from the network at https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.6.0-standalone-strict/volumeerror.json: Could not read schema from HTTP, response status is 404 Not Found\n\n"),
 	}}
 
 	if len(annotations) != len(want) {

--- a/validator/candidates_test.go
+++ b/validator/candidates_test.go
@@ -102,9 +102,7 @@ func TestLoadingCandidatesBytesFromGitHub(t *testing.T) {
 
 	ctx := context.Background()
 
-	schema := &KubeValidatorConfigSchema{
-		Strict: true,
-	}
+	schema := &KubeValidatorConfigSchema{}
 	var schemas []*KubeValidatorConfigSchema
 	schemas = append(schemas, schema)
 
@@ -144,7 +142,7 @@ func TestLoadingCandidatesBytesFromGitHub(t *testing.T) {
 			StartLine:       github.Int(1),
 			EndLine:         github.Int(1),
 			AnnotationLevel: github.String("failure"),
-			Title:           github.String("Error validating Deployment against strict schema"),
+			Title:           github.String("Error validating Deployment against default schema"),
 			Message:         github.String("extra: Additional property extra is not allowed"),
 			RawDetails:      github.String("* context: (root).spec\n* field: extra\n* property: extra\n"),
 		},
@@ -154,7 +152,7 @@ func TestLoadingCandidatesBytesFromGitHub(t *testing.T) {
 			StartLine:       github.Int(1),
 			EndLine:         github.Int(1),
 			AnnotationLevel: github.String("failure"),
-			Title:           github.String("Error validating Deployment against strict schema"),
+			Title:           github.String("Error validating Deployment against default schema"),
 			Message:         github.String("spec.replicas: Invalid type. Expected: integer, given: string"),
 			RawDetails:      github.String("* context: (root).spec.replicas\n* expected: integer\n* field: spec.replicas\n* given: string\n"),
 		},
@@ -164,7 +162,7 @@ func TestLoadingCandidatesBytesFromGitHub(t *testing.T) {
 			StartLine:       github.Int(1),
 			EndLine:         github.Int(1),
 			AnnotationLevel: github.String("failure"),
-			Title:           github.String("Error validating Deployment against strict schema"),
+			Title:           github.String("Error validating Deployment against default schema"),
 			Message:         github.String("extra-container: Additional property extra-container is not allowed"),
 			RawDetails:      github.String("* context: (root).spec.template.spec.containers.0\n* field: extra-container\n* property: extra-container\n"),
 		},
@@ -207,7 +205,6 @@ func TestLineNumbers(t *testing.T) {
 			ctx := context.Background()
 
 			schema := &KubeValidatorConfigSchema{
-				Strict:      true,
 				LineNumbers: true,
 			}
 			var schemas []*KubeValidatorConfigSchema

--- a/validator/config.go
+++ b/validator/config.go
@@ -34,7 +34,6 @@ type KubeValidatorConfigSchema struct {
 
 	Version     string `yaml:"version,omitempty"`
 	ConfigType  string `yaml:"type,omitempty"`
-	Strict      bool   `yaml:"strict,omitempty"`
 	LineNumbers bool   `yaml:"lineNumbers,omitempty"`
 }
 


### PR DESCRIPTION
Otherwise, typos in key names are silently ignore as they are considered "extra" keys.