### PR TITLE
Renamed files are important too

### DIFF
--- a/validator/github.go
+++ b/validator/github.go
@@ -215,8 +215,6 @@ func (c *Context) changedFileList(e *github.CheckSuiteEvent) ([]*github.CommitFi
 			// skip files that weren't added or changed
 			case "removed":
 				continue
-			case "renamed":
-				continue
 			default:
 				prFiles = append(prFiles, file)
 			}


### PR DESCRIPTION
An accidental regression introduced when fixing https://github.com/urcomputeringpal/kubevalidator/issues/52